### PR TITLE
Added Blender-like Orbit/Pan Controls

### DIFF
--- a/StudioCore/Gui/Viewport.cs
+++ b/StudioCore/Gui/Viewport.cs
@@ -176,7 +176,7 @@ namespace StudioCore.Gui
                 var s = ImGui.GetWindowSize();
                 var newvp = new Veldrid.Rectangle((int)p.X, (int)p.Y + 3, (int)s.X, (int)s.Y - 3);
                 ResizeViewport(_device, newvp);
-                if (InputTracker.GetMouseButtonDown(MouseButton.Right) && MouseInViewport())
+                if ((InputTracker.GetMouseButtonDown(MouseButton.Right) || InputTracker.GetMouseButtonDown(MouseButton.Middle)) && MouseInViewport())
                 {
                     ImGui.SetWindowFocus();
                 }
@@ -307,6 +307,8 @@ namespace StudioCore.Gui
             var pos = box.GetCenter();
             var radius = Vector3.Distance(box.Max, box.Min);
             _worldView.CameraTransform.Position = pos - (camdir * radius);
+            _worldView.OrbitCamCenter = pos;
+            _worldView.OrbitCamDistance = Math.Max(radius , _worldView.SHITTY_CAM_ZOOM_MIN_DIST);
         }
     }
 }


### PR DESCRIPTION
I added movement controls mapped to the middle mouse button and removed old orbit code.
-	Holding middle click will now orbit the camera around an invisible point "OrbitCamCenter" directly in front of the camera at distance "OrbitCamDistance".
- 	Pressing F changes the orbit point to match the object selected.
- 	Scrolling the mouse wheel will move the camera closer and further from the orbit point by adjusting "OrbitCamDistance".
- 	Holding shift and middle click will pan the view based on mouse movement.
- 	When panning or using WASD/Right click movement, the point "OrbitCamCenter" is moved to be directly in front of the camera at distance "OrbitCamDistance," so the two movement schemes can be switched between seamlessly.
- 	Changed Viewport.OnGui() to enable switching window focus with middle click. Without this, I had to click into the viewport before orbit controls would work.
- 	While I tried to remove the old orbit system, I can't tell what exactly MoveCamera_OrbitCenterPoint's Matrix math is doing, so I just commented it out on the chance the code will be needed elsewhere.